### PR TITLE
Allow detailed info to be retrieved by the ID.

### DIFF
--- a/lib/postcode_anywhere/capture_plus/interactive.rb
+++ b/lib/postcode_anywhere/capture_plus/interactive.rb
@@ -51,16 +51,12 @@ module PostcodeAnywhere
       end
 
       def retrieve(search_result)
-        options = {}
-        options.merge!(
-          'Id' => ParentIdExtractor.new(search_result).extract
-        )
-        perform_with_object(
-          :get,
-          RETRIEVE_ADDRESS_ENDPOINT,
-          options,
-          PostcodeAnywhere::CapturePlus::RetrieveResult
-        )
+        retrieve_by_id(ParentIdExtractor.new(search_result).extract)
+      end
+
+      def retrieve_by_id(id)
+        options = { 'Id': id }
+        perform_with_object(:get, RETRIEVE_ADDRESS_ENDPOINT, options, PostcodeAnywhere::CapturePlus::RetrieveResult)
       end
 
       class ParentIdExtractor

--- a/spec/postcode_anywhere/capture_plus/interactive_spec.rb
+++ b/spec/postcode_anywhere/capture_plus/interactive_spec.rb
@@ -184,6 +184,22 @@ describe PostcodeAnywhere::CapturePlus::Interactive do
       }
       @search_result = PostcodeAnywhere::CapturePlus::SearchResult.new(id: '888')
     end
+    describe '#retrieve_by_id' do
+      before do
+        stub_get(@endpoint).with(query: @retrieve_params).to_return(
+          body: fixture('capture_plus_retrieve.json')
+        )
+      end
+      it 'requests the correct resource' do
+        item = @client.retrieve_by_id('888')
+        expect(item).to be_a PostcodeAnywhere::CapturePlus::RetrieveResult
+        expect(item.id).to eq('GBR|PR|11507281|0|0|0')
+        expect(item.domestic_id).to eq '11507281'
+        expect(item.language).to eq 'ENG'
+        expect(item.language_alternatives).to eq 'ENG'
+        expect(item.department).to eq 'dpmnt'
+      end
+    end
     describe '#retrieve' do
       before do
         stub_get(@endpoint).with(query: @retrieve_params).to_return(


### PR DESCRIPTION
It is useful to be able to retrieve detailed address information by the returned ID, especially for web stuff. ie.

```ruby
address = client.retrieve_by_id('GBR|123456789)
```

I think that at the moment you need the result, or have to do something like:

```ruby
endpoint = PostcodeAnywhere::CapturePlus::Interactive::RETRIEVE_ADDRESS_ENDPOINT
options = {'Id' => 'GBR|123456789'}
address = client.perform_with_object(:get, endpoint, options, PostcodeAnywhere::CapturePlus::RetrieveResult)
```

